### PR TITLE
Generlized Makefile and UBI dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-IMAGE_NAME = anaconda-project-centos7
+IMAGE_PREFIX = anaconda-project
+BASE_IMAGES := $(basename $(wildcard *.dockerfile))
 
-.PHONY: build
-build:
-	docker build -t $(IMAGE_NAME) .
+all: $(BASE_IMAGES)
 
-.PHONY: test
-test:
-	docker build -t $(IMAGE_NAME)-candidate .
-	IMAGE_NAME=$(IMAGE_NAME)-candidate test/run
+.PHONY: $(BASE_IMAGES)
+$(BASE_IMAGES):
+	docker build -t $(IMAGE_PREFIX)-$@ -f $@.dockerfile .
+
+TEST_IMAGES := $(patsubst %,test-%,$(BASE_IMAGES))
+
+.PHONY: $(TEST_IMAGES)
+$(TEST_IMAGES):
+	docker build -t $(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate -f $(patsubst test-%,%,$@).dockerfile .
+	IMAGE_NAME=$(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate test/run

--- a/centos7.dockerfile
+++ b/centos7.dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y bzip2 && \
     conda install anaconda-project=0.8.4 --yes && \
     conda clean --all --yes && \
     rm -f condarc miniconda.sh && \
-    useradd anaconda
+    chmod -R 755 /opt/conda
 
 # TODO (optional): Copy the builder files into /opt/app-root
 # COPY ./<builder_folder>/ /opt/app-root/
@@ -40,7 +40,6 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 # TODO: Drop the root user and make the content of /opt/app-root owned by user 1001
 RUN chown -R 1001:1001 /opt/app-root
-RUN chown -R 1001:1001 /opt/conda
 
 # This default user is created in the openshift/base-centos7 image
 USER 1001

--- a/ubi7.dockerfile
+++ b/ubi7.dockerfile
@@ -1,0 +1,51 @@
+# anaconda-project-ubi7
+FROM registry.access.redhat.com/ubi7/s2i-base
+
+# TODO: Put the maintainer name in the image metadata
+LABEL maintainer="Anaconda, Inc."
+
+# TODO: Rename the builder environment variable to inform users about application you provide them
+ENV CONDA_VERSION=4.7.12.1
+ENV ANACONDA_PROJECT_VERSION=0.8.4
+
+# Set labels used in OpenShift to describe the builder images
+LABEL io.k8s.description="Run Anaconda Project commands" \
+      io.k8s.display-name="Anaconda Project 0.8.4" \
+      io.openshift.expose-services="8086:http" \
+      io.openshift.tags="builder,anaconda-project,conda" 
+
+ADD https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh miniconda.sh
+
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    PATH=/opt/conda/bin:$PATH 
+
+COPY ./etc/condarc .
+
+RUN yum install -y bzip2 && \
+    bash miniconda.sh -b -p /opt/conda && \
+    conda config --set auto_update_conda False --set notify_outdated_conda false --system && \
+    cp condarc /opt/conda/.condarc && \
+    conda install anaconda-project=0.8.4 --yes && \
+    conda clean --all --yes && \
+    rm -f condarc miniconda.sh && \
+    chmod -R 755 /opt/conda
+
+# TODO (optional): Copy the builder files into /opt/app-root
+# COPY ./<builder_folder>/ /opt/app-root/
+
+# TODO: Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image
+# sets io.openshift.s2i.scripts-url label that way, or update that label
+COPY ./s2i/bin/ /usr/libexec/s2i
+
+# TODO: Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:1001 /opt/app-root
+
+# This default user is created in the openshift/base-centos7 image
+USER 1001
+
+# TODO: Set the default port for applications built using this image
+EXPOSE 8086
+
+# TODO: Set the default CMD for the image
+CMD ["/usr/libexec/s2i/usage"]


### PR DESCRIPTION
Addresses #1 

* This project is now easily extended by adding new `<base-image>.dockerfile` files. Just run `make <base-image>` or `make test-<base-image>`.
* Added the `ubi7.dockerfile` built with [ubi7/s2i-base](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/using_red_hat_universal_base_images_standard_minimal_and_runtimes#using_red_hat_software_collections_runtime_images)
* The `.dockerfile` images make `/opt/conda` readable but not writable by the `1001` user