### PR TITLE
Add default command 'default' if command is missing

### DIFF
--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -7,4 +7,4 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
-exec anaconda-project run $CMD --anaconda-project-port=8086
+exec anaconda-project run ${CMD:-default} --anaconda-project-port=8086


### PR DESCRIPTION
Simply add a default "default" to the CMD environment variable if it is missing.  