### PR TITLE
anaconda-project-port must have space, not = !!!!

### DIFF
--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -7,4 +7,4 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
-exec anaconda-project run $CMD --anaconda-project-port=8086
+exec anaconda-project run $CMD --anaconda-project-port 8086


### PR DESCRIPTION
@bkreider , @mcg1969 

Just noticed this problem. If the `run` script has `--anaconda-project-port=8086` the argument is just ignored. It must be `--anaconda-project-port 8086`.