### PR TITLE
Enable correct initialization of docker cli commands 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,5 @@ $(TEST_IMAGES):
 	IMAGE_NAME=$(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate test/run-multi-env default py3
 	IMAGE_NAME=$(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate test/run-multi-env py2 py2
 	IMAGE_NAME=$(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate test/run-multi-env py3 py3
+	IMAGE_NAME=$(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate test/run-env-vars "" "CMD_VAR=cmd_value\nPROJECT_VAR=project_value\n"
+	IMAGE_NAME=$(IMAGE_PREFIX)-$(patsubst test-%,%,$@)-candidate test/run-env-vars "env" "PROJECT_VAR=project_value"

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -30,6 +30,9 @@ RUN apk add --no-cache --virtual wget tar bash \
     && wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh -O miniconda.sh \
     && sh miniconda.sh -u -b -p /opt/conda \
     && rm -f miniconda.sh \
+    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
+    && echo "conda activate base" >> ~/.bashrc \
     && conda install anaconda-project=0.10.0 anaconda-client conda-repo-cli conda-token tini --yes \
     && conda clean --all --yes \
     && chmod -R 755 /opt/conda 

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -31,8 +31,6 @@ RUN apk add --no-cache --virtual wget tar bash \
     && sh miniconda.sh -u -b -p /opt/conda \
     && rm -f miniconda.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
-    && echo "conda activate base" >> ~/.bashrc \
     && conda install anaconda-project=0.10.0 anaconda-client conda-repo-cli conda-token tini --yes \
     && conda clean --all --yes \
     && chmod -R 755 /opt/conda 
@@ -55,6 +53,6 @@ EXPOSE 8086
 
 WORKDIR $HOME
 
-ENTRYPOINT ["tini", "-g", "--"]
+ENTRYPOINT ["/usr/libexec/s2i/entrypoint.sh"]
 
 CMD ["/usr/libexec/s2i/usage"]

--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -48,5 +48,4 @@ if find_js; then
   find ./envs/*/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete
 fi
 
-env_spec=$(python -c "from anaconda_project.project import Project;print(Project('.').command_for_name('${project_command}').default_env_spec_name)")
-sed -i "s:conda activate base:conda activate ./envs/${env_spec}:" ~/.bashrc
+touch .assembled

--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -47,3 +47,6 @@ find ./envs/* -follow -type f -name '*.js.map' -delete
 if find_js; then
   find ./envs/*/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete
 fi
+
+env_spec=$(python -c "from anaconda_project.project import Project;print(Project('.').command_for_name('${project_command}').default_env_spec_name)")
+sed -i "s:conda activate base:conda activate ./envs/${env_spec}:" ~/.bashrc

--- a/s2i/bin/entrypoint.sh
+++ b/s2i/bin/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+eval "$(conda shell.bash hook)"
+
+if [ -e /opt/app-root/src/.assembled ]; then
+    project_command=${CMD:-default}
+    env_spec=$(python -c "from anaconda_project.project import Project;print(Project('.').command_for_name('${project_command}').default_env_spec_name)")
+    conda activate ./envs/${env_spec}
+else
+    conda activate base
+fi
+
+exec tini -g -- "$@"

--- a/s2i/bin/entrypoint.sh
+++ b/s2i/bin/entrypoint.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-eval "$(conda shell.bash hook)"
-
 if [ -e /opt/app-root/src/.assembled ]; then
-    project_command=${CMD:-default}
-    env_spec=$(python -c "from anaconda_project.project import Project;print(Project('.').command_for_name('${project_command}').default_env_spec_name)")
-    conda activate ./envs/${env_spec}
+    if [[ $1 == "/usr/libexec/s2i/run" ]]; then
+        exec tini -g -- "$@"
+    else
+        exec tini -g -- anaconda-project run "$@"
+    fi
 else
-    conda activate base
+    exec tini -g -- "$@"
 fi
-
-exec tini -g -- "$@"

--- a/test/run-env-vars
+++ b/test/run-env-vars
@@ -1,0 +1,159 @@
+#!/bin/bash
+#
+# The 'run' performs a simple test that verifies the S2I image.
+# The main focus here is to exercise the S2I scripts.
+#
+# For more information see the documentation:
+# https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+# IMAGE_NAME=${IMAGE_NAME-anaconda-project-centos7-candidate}
+COMMAND="$1"
+EXPECTED_OUTPUT="$2"
+
+# Determining system utility executables (darwin compatibility check)
+READLINK_EXEC="readlink -zf"
+MKTEMP_EXEC="mktemp --suffix=.cid"
+if [[ "$OSTYPE" =~ 'darwin' ]]; then
+  READLINK_EXEC="readlink"
+  MKTEMP_EXEC="mktemp"
+  ! type -a "greadlink" &>"/dev/null" || READLINK_EXEC="greadlink"
+  ! type -a "gmktemp" &>"/dev/null" || MKTEMP_EXEC="gmktemp"
+fi
+
+_dir="$(dirname "${BASH_SOURCE[0]}")"
+test_dir="$($READLINK_EXEC ${_dir} || echo ${_dir})"
+image_dir=$($READLINK_EXEC ${test_dir}/.. || echo ${test_dir}/..)
+scripts_url="${image_dir}/.s2i/bin"
+cid_file=$($MKTEMP_EXEC -u)
+
+# Since we built the candidate image locally, we don't want S2I to attempt to pull
+# it from Docker hub
+s2i_args="--pull-policy=never --loglevel=2"
+
+# Port the image exposes service to be tested
+test_port=8086
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+container_exists() {
+  image_exists $(cat $cid_file)
+}
+
+container_ip() {
+  docker inspect --format="{{(index .NetworkSettings.Ports \"$test_port/tcp\" 0).HostIp }}" $(cat $cid_file) | sed 's/0.0.0.0/localhost/'
+}
+
+container_port() {
+  docker inspect --format="{{(index .NetworkSettings.Ports \"$test_port/tcp\" 0).HostPort }}" "$(cat "${cid_file}")"
+}
+
+run_s2i_build() {
+  local cmd="$1"
+  s2i build --incremental=true ${s2i_args} ${test_dir}/test-env-vars ${IMAGE_NAME} ${IMAGE_NAME}-testproject -e CMD=$cmd
+}
+
+prepare() {
+  if ! image_exists ${IMAGE_NAME}; then
+    echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
+    exit 1
+  fi
+  # s2i build requires the application is a valid 'Git' repository
+  pushd ${test_dir}/test-env-vars >/dev/null
+  git init
+  git config user.email "build@localhost" && git config user.name "builder"
+  git add -A && git commit -m "Sample commit"
+  popd >/dev/null
+  run_s2i_build
+}
+
+run_default() {
+  docker run --rm --cidfile=${cid_file} -p ${test_port}:${test_port} ${IMAGE_NAME}-testproject
+}
+
+run_env_cmd() {
+  docker run --rm --cidfile=${cid_file} -p ${test_port}:${test_port} ${IMAGE_NAME}-testproject env | grep "_VAR"
+}
+
+cleanup() {
+  if [ -f $cid_file ]; then
+    if container_exists; then
+      docker stop $(cat $cid_file)
+    fi
+  fi
+  if image_exists ${IMAGE_NAME}-testapp; then
+    docker rmi ${IMAGE_NAME}-testapp
+  fi
+}
+
+check_result() {
+  local result="$1"
+  if [[ "$result" != "0" ]]; then
+    echo "S2I image '${IMAGE_NAME}' test FAILED (exit code: ${result})"
+    cleanup
+    exit $result
+  fi
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && break
+    echo "Waiting for container to start..."
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+test_usage() {
+  echo "Testing 's2i usage'..."
+  s2i usage ${s2i_args} ${IMAGE_NAME} &>/dev/null
+}
+
+test_env_vars() {
+  local output="$1"
+  local expected="$2"
+  local result=1
+  echo "Testing for correct env vars"
+  echo "Expected: ${expected} -- Found ${output}"
+  if [[ "$output" == "$expected" ]]; then
+    result=0
+  fi
+  return $result
+}
+
+
+# Build the application image twice to ensure the 'save-artifacts' and
+# 'restore-artifacts' scripts are working properly
+prepare
+run_s2i_build default #$COMMAND
+check_result $?
+
+# Verify the 'usage' script is working properly
+test_usage
+check_result $?
+
+# Run the default command
+if [[ "$COMMAND" == "" ]]; then
+  output=`run_default`
+elif [[ "$COMMAND" == "env" ]]; then
+  output=`run_env_cmd`
+else
+  echo "$COMMAND is not accepted as a command for run-env-vars"
+  exit 1
+fi
+
+# Wait for the container to write its CID file
+wait_for_cid
+
+test_env_vars "$output" "$EXPECTED_OUTPUT"
+check_result $?
+
+cleanup

--- a/test/test-env-vars/.projectignore
+++ b/test/test-env-vars/.projectignore
@@ -1,0 +1,18 @@
+# This file contains a list of match patterns that instructs
+# anaconda-project to exclude certain files or directories when
+# building a project archive. The file format is a simplfied
+# version of Git's .gitignore file format. In fact, if the
+# project is hosted in a Git repository, these patterns can be
+# merged into the .gitignore file and this file removed.
+# See the anaconda-project documentation for more details.
+
+# Python caching
+*.pyc
+*.pyd
+*.pyo
+__pycache__/
+
+# Jupyter & Spyder stuff
+.ipynb_checkpoints/
+.Trash-*/
+/.spyderproject

--- a/test/test-env-vars/anaconda-project.yml
+++ b/test/test-env-vars/anaconda-project.yml
@@ -1,0 +1,13 @@
+name: test-env-vars
+
+packages: []
+
+variables:
+  PROJECT_VAR:
+    default: "project_value"
+
+commands:
+  default:
+    unix: env | grep "_VAR" | sort | sed 's/$/\\n/g' | tr -d '\n'
+    variables:
+      CMD_VAR: "cmd_value"

--- a/ubi7.dockerfile
+++ b/ubi7.dockerfile
@@ -21,8 +21,6 @@ RUN yum install -y wget bzip2 \
     && bash miniconda.sh -u -b -p /opt/conda \
     && rm -f miniconda.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
-    && echo "conda activate base" >> ~/.bashrc \
     && conda install anaconda-project=0.10.0 anaconda-client conda-repo-cli conda-token tini --yes \
     && conda clean --all --yes \
     && chmod -R 755 /opt/conda
@@ -42,6 +40,6 @@ USER 1001
 
 EXPOSE 8086
 
-ENTRYPOINT ["tini", "-g", "--"]
+ENTRYPOINT ["/usr/libexec/s2i/entrypoint.sh"]
 
 CMD ["/usr/libexec/s2i/usage"]

--- a/ubi7.dockerfile
+++ b/ubi7.dockerfile
@@ -19,9 +19,12 @@ COPY ./etc/condarc /opt/conda/.condarc
 RUN yum install -y wget bzip2 \
     && wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh -O miniconda.sh \
     && bash miniconda.sh -u -b -p /opt/conda \
+    && rm -f miniconda.sh \
+    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
+    && echo "conda activate base" >> ~/.bashrc \
     && conda install anaconda-project=0.10.0 anaconda-client conda-repo-cli conda-token tini --yes \
     && conda clean --all --yes \
-    && rm -f miniconda.sh \
     && chmod -R 755 /opt/conda
 
 COPY ./s2i/bin/ /usr/libexec/s2i

--- a/ubi8.dockerfile
+++ b/ubi8.dockerfile
@@ -19,10 +19,13 @@ COPY ./etc/condarc /opt/conda/.condarc
 RUN yum install -y wget bzip2 \
     && wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh -O miniconda.sh \
     && bash miniconda.sh -u -b -p /opt/conda \
+    && rm -f miniconda.sh \
+    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
+    && echo "conda activate base" >> ~/.bashrc \
     && conda install anaconda-project=0.10.0 anaconda-client conda-repo-cli conda-token tini --yes \
     && conda clean --all --yes \
-    && rm -f miniconda.sh \
-    && chmod -R 755 /opt/conda
+    && chmod -R 755 /opt/conda 
 
 COPY ./s2i/bin/ /usr/libexec/s2i
 

--- a/ubi8.dockerfile
+++ b/ubi8.dockerfile
@@ -21,8 +21,6 @@ RUN yum install -y wget bzip2 \
     && bash miniconda.sh -u -b -p /opt/conda \
     && rm -f miniconda.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
-    && echo "conda activate base" >> ~/.bashrc \
     && conda install anaconda-project=0.10.0 anaconda-client conda-repo-cli conda-token tini --yes \
     && conda clean --all --yes \
     && chmod -R 755 /opt/conda 
@@ -42,6 +40,6 @@ USER 1001
 
 EXPOSE 8086
 
-ENTRYPOINT ["tini", "-g", "--"]
+ENTRYPOINT ["/usr/libexec/s2i/entrypoint.sh"]
 
 CMD ["/usr/libexec/s2i/usage"]


### PR DESCRIPTION
By default `docker run <image>` will execute `anaconda-project run <command-chosen-at-build-time>` to run the command that was built when s2i build was run.

This PR enables correct project initialization (particularly environment variables) when `docker run <image> <command-chosen-at-runtime>` is run. In the entrypoint for the image executes `anaconda-project run <command-chosen-at-runtime>`. This runtime command can be a defined command (and arguments) or any executable on the project environment path, again with arguments. Here's an example


This project defines an environment variable and runs the a webserver. 

```yaml
name: run-me

packages:
  - python=3.8

variables:
  VAR:
    default: value

commands:
  default:
    unix: python -m http.server 8086
```

Building the image and running it results in

```
> s2i build -c .  conda/s2i-anaconda-project-alpine webserver:latest
> docker run webserver:latest
Serving HTTP on 0.0.0.0 port 8086 (http://0.0.0.0:8086/) ...
```

Now, you can also run an arbitrary command at container runtime

```
> docker run webserver:latest python -c 'import os;print(os.environ["VAR"])'
value
```

And you'll notice that the default env_spec is activated

```
> docker run webserver python -c  'import sys;print(sys.executable)'
/opt/app-root/src/envs/default/bin/python
```